### PR TITLE
usm: http, http2: Try drop rules first

### DIFF
--- a/pkg/network/protocols/http/statkeeper.go
+++ b/pkg/network/protocols/http/statkeeper.go
@@ -8,6 +8,7 @@
 package http
 
 import (
+	"slices"
 	"strconv"
 	"sync"
 	"time"
@@ -47,6 +48,22 @@ func NewStatkeeper(c *config.Config, telemetry *Telemetry, incompleteBuffer Inco
 	var connectionAggregator *utils.ConnectionAggregator
 	if c.EnableUSMConnectionRollup {
 		connectionAggregator = utils.NewConnectionAggregator()
+	}
+
+	if len(c.HTTPReplaceRules) > 0 {
+		// Sort rules, and place drop rules first
+		slices.SortStableFunc(c.HTTPReplaceRules, func(a, b *config.ReplaceRule) int {
+			if a.Repl == "" && b.Repl == "" {
+				return 0
+			}
+			if a.Repl == "" {
+				return -1
+			}
+			if b.Repl == "" {
+				return 1
+			}
+			return 0
+		})
 	}
 
 	return &StatKeeper{


### PR DESCRIPTION
Small improvement for the case we have a drop rule, then we should try them first and not using all other replacement rules

<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->